### PR TITLE
Add building of native wheels on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,118 @@
-language: python
-
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-
+matrix:
+  include:
+    - name: linux-py27
+      language: python
+      python: 2.7
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip
+        - CIBW_BUILD=cp27-*
+    - name: linux-py34
+      language: python
+      python: 3.4
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip
+        - CIBW_BUILD=cp34-*
+    - name: linux-py35
+      language: python
+      python: 3.5
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip3
+        - CIBW_BUILD=cp35-*
+    - name: linux-py36
+      language: python
+      python: 3.6
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip3
+        - CIBW_BUILD=cp36-*
+    - name: linux-py37
+      language: python
+      python: 3.7
+      dist: xenial
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip3
+        - CIBW_BUILD=cp37-*
+    - name: osx-py27
+      os: osx
+      language: generic
+      env:
+        - PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin:$PATH"
+        - PIP=pip
+        - CIBW_BUILD=cp27-*
+        - CIBW_TEST_COMMAND="pushd {project}; make lint; make test ; popd"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install 'flake8<3' pytest"
+      install:
+        - ${PIP} install cibuildwheel==0.10.2
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py34
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp34-*
+        - CIBW_TEST_COMMAND="pushd {project}; make lint; make test ; popd"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install 'flake8<3' pytest"
+      install:
+        - ${PIP} install cibuildwheel==0.10.2
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py35
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp35-*
+        - CIBW_TEST_COMMAND="pushd {project}; make lint; make test ; popd"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install 'flake8<3' pytest"
+      install:
+        - ${PIP} install cibuildwheel==0.10.2
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py36
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp36-*
+        - CIBW_TEST_COMMAND="pushd {project}; make lint; make test ; popd"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install 'flake8<3' pytest"
+      install:
+        - ${PIP} install cibuildwheel==0.10.2
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py37
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp37-*
+        - CIBW_TEST_COMMAND="pushd {project}; make lint; make test ; popd"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install 'flake8<3' pytest"
+      install:
+        - ${PIP} install cibuildwheel==0.10.2
+      script:
+        - cibuildwheel --output-dir dist
 install:
-  - "pip install 'flake8<3' pytest"
-
+  - "${PIP} install -U pip"
+  - "${PIP} install 'flake8<3' pytest"
+  - "${PIP} install cibuildwheel==0.10.2"
 script:
   - make lint
   - make test
-
-sudo: false
+  - git stash --all # Restore fresh checkout
+  - cibuildwheel --output-dir dist


### PR DESCRIPTION
This would address building of wheels for https://github.com/lithammer/python-jump-consistent-hash/issues/14

Sorry for such convoluted handling of `osx` due to TravisCI not having first class support for `python` on `osx` (https://github.com/travis-ci/travis-ci/issues/9929).

Uploading of wheels to PyPi could be added like https://github.com/joerick/cibuildwheel-autopypi-example/blob/master/.travis.yml#L21-L25